### PR TITLE
Fix Chrome Version Number Regex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ CHROMEDRIVER_URL_TEMPLATE = (
     '{architecture}.zip'
 )
 
-CHROMEDRIVER_VERSION_PATTERN = re.compile(r'^\d+\.\d+$')
+CHROMEDRIVER_VERSION_PATTERN = re.compile(r'^\d+\.\d+(.\d+\.\d+){0,1}$')
 CROMEDRIVER_LATEST_VERSION_PATTERN = re.compile(
     r'Latest-Release:-ChromeDriver-(\d+\.\d+)'
 )


### PR DESCRIPTION
Chrome Driver versions have moved from a #.# to a #.#.#.# number format in newer versions. A check in this setup script was throwing an Invalid Chromedriver-version error an exception incorrectly. This change fixes that error.